### PR TITLE
Issue 3677 Better logging for using Synonymous erroneously

### DIFF
--- a/src/scweaver/Starcounter.Internal.Weaver/ScAnalysisTask.cs
+++ b/src/scweaver/Starcounter.Internal.Weaver/ScAnalysisTask.cs
@@ -799,7 +799,7 @@ namespace Starcounter.Internal.Weaver {
                     ScMessageSource.WriteError(
                                 MessageLocation.Unknown,
                                 Error.SCERRUNSPECIFIED,
-                                "Illegal element for the SynonymousTo attribute");
+                                "Illegal element for the SynonymousTo attribute: " + synonymToEnumerator.Current.TargetElement);
                 }
             }
         }


### PR DESCRIPTION
Added the ToString of the current TargetElement of the synonymToEnumerator